### PR TITLE
Add sulu.conf to fix nginx config

### DIFF
--- a/.ddev/nginx/sulu.conf
+++ b/.ddev/nginx/sulu.conf
@@ -1,0 +1,8 @@
+location ~* \.(?:ico|css|js|gif|jpe?g|png|svg|woff|woff2|eot|ttf)$ {
+    # try to serve file directly, fallback to index.php
+    try_files $uri /index.php$is_args$args;
+    access_log off;
+    expires 30d;
+    add_header Pragma public;
+    add_header Cache-Control "public";
+}


### PR DESCRIPTION
This PR try to overwrite the JPG part for default nginx conf in ddev.

The Part in `/etc/nginx/nginx_default.conf` contains:

```
    # Media: images, icons, video, audio, HTC
    location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|svgz|mp4|ogg|ogv|webm|htc)$ {
        expires 1M;
        access_log off;
        add_header Cache-Control "public";
    }
```